### PR TITLE
Upgrade Cake

### DIFF
--- a/AssemblyInfo.cs
+++ b/AssemblyInfo.cs
@@ -3,22 +3,24 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text.RegularExpressions;
 
+using Cake.Core.IO;
+
 namespace Dnn.CakeUtils
 {
     public class AssemblyInfo
     {
-        private string FilePath { get; set; }
+        private FilePath FilePath { get; set; }
         private bool IsVB { get; set; } = false;
         private Dictionary<int, string> Lines { get; set; } = new Dictionary<int, string>();
         private Dictionary<string, string> StringProperties = new Dictionary<string, string>();
         private Dictionary<int, string> StringPropLines = new Dictionary<int, string>();
-        public AssemblyInfo(string filePath)
+        public AssemblyInfo(FilePath filePath)
         {
             FilePath = filePath;
-            IsVB = Path.GetExtension(filePath).ToLower().EndsWith(".vb");
+            IsVB = filePath.GetExtension().EndsWith(".vb", StringComparison.OrdinalIgnoreCase);
             var regex = IsVB ? @"^\<Assembly\: ([^\(]+)\(""(.*)\""\)\>" : @"^\[assembly\: ([^\(]+)\(""(.*)\""\)\]";
             var lineNr = 0;
-            using (var sr = new StreamReader(filePath, System.Text.Encoding.UTF8))
+            using (var sr = new StreamReader(filePath.FullPath, System.Text.Encoding.UTF8))
             {
                 while (!sr.EndOfStream)
                 {
@@ -49,10 +51,10 @@ namespace Dnn.CakeUtils
         {
             Write(FilePath);
         }
-        public void Write(string filePath)
+        public void Write(FilePath filePath)
         {
             var pattern = IsVB ? "<Assembly: {0}(\"{1}\")>" : "[assembly: {0}(\"{1}\")]";
-            using (var sw = new StreamWriter(filePath, false, System.Text.Encoding.UTF8))
+            using (var sw = new StreamWriter(filePath.FullPath, false, System.Text.Encoding.UTF8))
             {
                 for (var lineNr = 0; lineNr < Lines.Count; lineNr++)
                 {

--- a/Compression.cs
+++ b/Compression.cs
@@ -3,28 +3,30 @@ using System.IO;
 using System.IO.Compression;
 using System.Xml;
 
+using Cake.Common.Diagnostics;
+using Cake.Core;
 using Cake.Core.IO;
 
 namespace Dnn.CakeUtils
 {
     public static class Compression
     {
-        public static void AddBinaryFileToZip(FilePath zipFile, byte[] content, FilePath name)
+        public static void AddBinaryFileToZip(this ICakeContext context, FilePath zipFile, byte[] content, FilePath name)
         {
-            AddBinaryFileToZip(zipFile, content, name, false);
+            context.AddBinaryFileToZip(zipFile, content, name, false);
         }
-        public static void AddBinaryFileToZip(FilePath zipFile, byte[] content, FilePath name, bool append)
+        public static void AddBinaryFileToZip(this ICakeContext context, FilePath zipFile, byte[] content, FilePath name, bool append)
         {
             using (var sr = new MemoryStream(content))
             {
-                AddStreamToZip(zipFile, sr, name, append);
+                context.AddStreamToZip(zipFile, sr, name, append);
             }
         }
-        public static void AddXmlFileToZip(FilePath zipFile, XmlDocument content, FilePath name)
+        public static void AddXmlFileToZip(this ICakeContext context, FilePath zipFile, XmlDocument content, FilePath name)
         {
-            AddXmlFileToZip(zipFile, content, name, false);
+            context.AddXmlFileToZip(zipFile, content, name, false);
         }
-        public static void AddXmlFileToZip(FilePath zipFile, XmlDocument content, FilePath name, bool append)
+        public static void AddXmlFileToZip(this ICakeContext context, FilePath zipFile, XmlDocument content, FilePath name, bool append)
         {
             using (var ms = new MemoryStream())
             {
@@ -34,41 +36,41 @@ namespace Dnn.CakeUtils
                 writer.Flush();
                 ms.Flush();
                 ms.Position = 0;
-                AddStreamToZip(zipFile, ms, name, append);
+                context.AddStreamToZip(zipFile, ms, name, append);
             }
         }
-        public static void AddTextFileToZip(FilePath zipFile, string content, FilePath name)
+        public static void AddTextFileToZip(this ICakeContext context, FilePath zipFile, string content, FilePath name)
         {
-            AddTextFileToZip(zipFile, content, name, false);
+            context.AddTextFileToZip(zipFile, content, name, false);
         }
-        public static void AddTextFileToZip(FilePath zipFile, string content, FilePath name, bool append)
+        public static void AddTextFileToZip(this ICakeContext context, FilePath zipFile, string content, FilePath name, bool append)
         {
-            using (var sr = GenerateStreamFromString(content))
+            using (var sr = context.GenerateStreamFromString(content))
             {
-                AddStreamToZip(zipFile, sr, name, append);
+                context.AddStreamToZip(zipFile, sr, name, append);
             }
         }
-        public static void AddFilesToZip(FilePath zipFile, FilePathCollection files)
+        public static void AddFilesToZip(this ICakeContext context, FilePath zipFile, FilePathCollection files)
         {
-            AddFilesToZip(zipFile, ".", "", files, false);
+            context.AddFilesToZip(zipFile, ".", "", files, false);
         }
-        public static void AddFilesToZip(FilePath zipFile, FilePathCollection files, bool append)
+        public static void AddFilesToZip(this ICakeContext context, FilePath zipFile, FilePathCollection files, bool append)
         {
-            AddFilesToZip(zipFile, ".", "", files, append);
+            context.AddFilesToZip(zipFile, ".", "", files, append);
         }
-        public static void AddFilesToZip(FilePath zipFile, DirectoryPath root, FilePathCollection files)
+        public static void AddFilesToZip(this ICakeContext context, FilePath zipFile, DirectoryPath root, FilePathCollection files)
         {
-            AddFilesToZip(zipFile, root, "", files, false);
+            context.AddFilesToZip(zipFile, root, "", files, false);
         }
-        public static void AddFilesToZip(FilePath zipFile, DirectoryPath root, FilePathCollection files, bool append)
+        public static void AddFilesToZip(this ICakeContext context, FilePath zipFile, DirectoryPath root, FilePathCollection files, bool append)
         {
-            AddFilesToZip(zipFile, root, "", files, append);
+            context.AddFilesToZip(zipFile, root, "", files, append);
         }
-        public static void AddFilesToZip(FilePath zipFile, DirectoryPath root, DirectoryPath newRoot, FilePathCollection files)
+        public static void AddFilesToZip(this ICakeContext context, FilePath zipFile, DirectoryPath root, DirectoryPath newRoot, FilePathCollection files)
         {
-            AddFilesToZip(zipFile, root, newRoot, files, false);
+            context.AddFilesToZip(zipFile, root, newRoot, files, false);
         }
-        public static void AddFilesToZip(FilePath zipFile, DirectoryPath root, DirectoryPath newRoot, FilePathCollection files, bool append)
+        public static void AddFilesToZip(this ICakeContext context, FilePath zipFile, DirectoryPath root, DirectoryPath newRoot, FilePathCollection files, bool append)
         {
             if (!append)
             {
@@ -81,19 +83,19 @@ namespace Dnn.CakeUtils
             var rootPath = root.FullPath;
             foreach (var file in files)
             {
-                Console.WriteLine("Reading " + file.FullPath);
+                context.Information("Reading " + file.FullPath);
                 using (var fileToZip = new FileStream(file.FullPath, FileMode.Open, FileAccess.Read))
                 {
                     var pathInZip = newRoot.CombineWithFilePath(file.FullPath.Substring(rootPath.Length + 1));
-                    AddStreamToZip(zipFile, fileToZip, pathInZip, true);
+                    context.AddStreamToZip(zipFile, fileToZip, pathInZip, true);
                 }
             }
         }
-        public static void AddStreamToZip(FilePath zipFile, Stream fileToZip, FilePath name)
+        public static void AddStreamToZip(this ICakeContext context, FilePath zipFile, Stream fileToZip, FilePath name)
         {
-            AddStreamToZip(zipFile, fileToZip, name, false);
+            context.AddStreamToZip(zipFile, fileToZip, name, false);
         }
-        public static void AddStreamToZip(FilePath zipFile, Stream fileToZip, FilePath name, bool append)
+        public static void AddStreamToZip(this ICakeContext context, FilePath zipFile, Stream fileToZip, FilePath name, bool append)
         {
             if (!append)
             {
@@ -106,14 +108,14 @@ namespace Dnn.CakeUtils
             {
                 using (var outStream = new ZipArchive(outFile, append ? ZipArchiveMode.Update : ZipArchiveMode.Create))
                 {
-                    Console.WriteLine("Zipping " + name);
+                    context.Information("Zipping " + name);
                     var entry = outStream.CreateEntry(name.FullPath);
                     fileToZip.CopyTo(entry.Open());
                 }
             }
         }
 
-        public static Stream ZipToStream(DirectoryPath root, FilePathCollection files)
+        public static Stream ZipToStream(this ICakeContext context, DirectoryPath root, FilePathCollection files)
         {
             var rootPath = root.FullPath;
             var outStream = new MemoryStream();
@@ -121,7 +123,7 @@ namespace Dnn.CakeUtils
             {
                 foreach (var file in files)
                 {
-                    Console.WriteLine("Zipping " + file.FullPath);
+                    context.Information("Zipping " + file.FullPath);
                     var fileInArchive = archive.CreateEntry(file.FullPath.Substring(rootPath.Length + 1), CompressionLevel.Optimal);
                     using (var entryStream = fileInArchive.Open())
                     using (var fileToCompressStream = new FileStream(file.FullPath, FileMode.Open, FileAccess.Read))
@@ -133,7 +135,7 @@ namespace Dnn.CakeUtils
             return outStream;
         }
 
-        public static byte[] ZipToBytes(DirectoryPath root, FilePathCollection files)
+        public static byte[] ZipToBytes(this ICakeContext context, DirectoryPath root, FilePathCollection files)
         {
             var rootPath = root.FullPath;
             byte[] compressedBytes;
@@ -144,7 +146,7 @@ namespace Dnn.CakeUtils
                 {
                     foreach (var file in files)
                     {
-                        Console.WriteLine("Zipping " + file.FullPath);
+                        context.Information("Zipping " + file.FullPath);
                         var fileInArchive = archive.CreateEntry(file.FullPath.Substring(rootPath.Length + 1), CompressionLevel.Optimal);
                         using (var entryStream = fileInArchive.Open())
                         using (var fileToCompressStream = new FileStream(file.FullPath, FileMode.Open, FileAccess.Read))
@@ -158,7 +160,7 @@ namespace Dnn.CakeUtils
             return compressedBytes;
         }
 
-        public static void AddFile(FilePath sourcePath, Stream zip)
+        public static void AddFile(this ICakeContext context, FilePath sourcePath, Stream zip)
         {
             using (FileStream src = new FileStream(sourcePath.FullPath, FileMode.Open, FileAccess.Read))
             {
@@ -166,7 +168,7 @@ namespace Dnn.CakeUtils
             }
         }
 
-        public static void CopyStream(Stream source, Stream destination, int bufferSize)
+        public static void CopyStream(this ICakeContext context, Stream source, Stream destination, int bufferSize)
         {
             byte[] bBuffer = new byte[bufferSize + 1];
             int iLengthOfReadChunk;
@@ -182,12 +184,12 @@ namespace Dnn.CakeUtils
             while (true);
         }
 
-        public static MemoryStream GenerateStreamFromString(string value)
+        public static MemoryStream GenerateStreamFromString(this ICakeContext context, string value)
         {
             return new MemoryStream(System.Text.Encoding.UTF8.GetBytes(value ?? ""));
         }
 
-        public static void SaveStream(Stream input, FilePath filePath)
+        public static void SaveStream(this ICakeContext context, Stream input, FilePath filePath)
         {
             if (input.CanSeek)
             {
@@ -199,7 +201,7 @@ namespace Dnn.CakeUtils
             }
         }
 
-        public static void SaveBytes(byte[] input, FilePath filePath)
+        public static void SaveBytes(this ICakeContext context, byte[] input, FilePath filePath)
         {
             using (var outFile = new FileStream(filePath.FullPath, FileMode.OpenOrCreate, FileAccess.Write))
             using (var fileToSave = new MemoryStream(input))

--- a/CsProjFile.cs
+++ b/CsProjFile.cs
@@ -1,17 +1,19 @@
 ﻿using System.Xml;
 
+using Cake.Core.IO;
+
 namespace Dnn.CakeUtils
 {
     public class CsProjFile : XmlDocument
     {
-        private string FilePath { get; set; }
+        private FilePath FilePath { get; set; }
 
         public bool IsNetCore { get; set; } = false;
 
-        public CsProjFile(string filePath)
+        public CsProjFile(FilePath filePath)
         {
             FilePath = filePath;
-            base.Load(filePath);
+            base.Load(filePath.FullPath);
             if (this.DocumentElement.HasAttribute("Sdk"))
             {
                 IsNetCore = true;
@@ -60,9 +62,9 @@ namespace Dnn.CakeUtils
         {
             Write(FilePath);
         }
-        public void Write(string filePath)
+        public void Write(FilePath filePath)
         {
-            Save(filePath);
+            Save(filePath.FullPath);
         }
 
     }

--- a/Dnn.CakeUtils.csproj
+++ b/Dnn.CakeUtils.csproj
@@ -7,14 +7,14 @@
     <Description>Utilities to support Cake scripts for building and packaging DNN extensions</Description>
     <PackageProjectUrl>https://github.com/DNNCommunity/Dnn.CakeUtils</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/DNNCommunity/Dnn.CakeUtils/blob/master/LICENSE</PackageLicenseUrl>
-    <Version>1.1.11</Version>
-    <AssemblyVersion>1.1.11.0</AssemblyVersion>
-    <FileVersion>1.1.11.0</FileVersion>
+    <Version>2.0.0</Version>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+    <FileVersion>2.0.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Common" Version="0.37.0" />
-    <PackageReference Include="Cake.Core" Version="0.37.0" />
+    <PackageReference Include="Cake.Common" Version="1.0.0" />
+    <PackageReference Include="Cake.Core" Version="1.0.0" />
     <PackageReference Include="Markdig" Version="0.20.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>

--- a/Extensions.cs
+++ b/Extensions.cs
@@ -53,12 +53,11 @@ namespace Dnn.CakeUtils
             res.LoadXml(value);
             return res;
         }
-        public static bool Contains(this FilePathCollection input, string filePath)
+        public static bool Contains(this FilePathCollection input, FilePath filePath)
         {
-            filePath = filePath.Replace("\\", "/");
             foreach (var fp in input)
             {
-                if (fp.FullPath == filePath)
+                if (fp.FullPath == filePath.FullPath)
                 {
                     return true;
                 }

--- a/Globbing.cs
+++ b/Globbing.cs
@@ -1,5 +1,4 @@
-﻿using Cake.Common.Diagnostics;
-using Cake.Common.IO;
+﻿using Cake.Common.IO;
 using Cake.Core;
 using Cake.Core.Annotations;
 using Cake.Core.IO;
@@ -59,13 +58,12 @@ namespace Dnn.CakeUtils
         }
 
         [CakeMethodAlias]
-        public static FilePathCollection GetFilesByPatterns(this ICakeContext context, string root, string[] includePatterns)
+        public static FilePathCollection GetFilesByPatterns(this ICakeContext context, DirectoryPath root, string[] includePatterns)
         {
-            root = root.EnsureEndsWith("/");
             var res = new FilePathCollection();
             for (var i = 0; i < includePatterns.Length; i++)
             {
-                var incl = context.GetFiles(root + includePatterns[i].TrimStart('/'));
+                var incl = context.GetFiles(root.CombineWithFilePath(includePatterns[i].TrimStart('/')).ToString());
                 var crt = res.Select(ii => ii.FullPath);
                 foreach (var include in incl)
                 {
@@ -79,24 +77,23 @@ namespace Dnn.CakeUtils
         }
 
         [CakeMethodAlias]
-        public static FilePathCollection GetFilesByPatterns(this ICakeContext context, string root, string[] includePatterns, string[] excludePatterns)
+        public static FilePathCollection GetFilesByPatterns(this ICakeContext context, DirectoryPath root, string[] includePatterns, string[] excludePatterns)
         {
             if (excludePatterns.Length == 0)
             {
                 return GetFilesByPatterns(context, includePatterns);
             }
-
-            root = root.EnsureEndsWith("/");
-            FilePathCollection excludeFiles = context.GetFiles(root + excludePatterns[0].TrimStart('/'));
+            
+            var excludeFiles = context.GetFiles(root.CombineWithFilePath(excludePatterns[0].TrimStart('/')).ToString());
             for (var i = 1; i < excludePatterns.Length; i++)
             {
-                excludeFiles.Add(context.GetFiles(root + excludePatterns[i].TrimStart('/')));
+                excludeFiles.Add(context.GetFiles(root.CombineWithFilePath(excludePatterns[i].TrimStart('/')).ToString()));
             }
             var excludePaths = excludeFiles.Select(e => e.FullPath);
             var res = new FilePathCollection();
             for (var i = 0; i < includePatterns.Length; i++)
             {
-                var incl = context.GetFiles(root + includePatterns[i].TrimStart('/'));
+                var incl = context.GetFiles(root.CombineWithFilePath(includePatterns[i].TrimStart('/')).ToString());
                 var crt = res.Select(ii => ii.FullPath);
                 foreach (var include in incl)
                 {

--- a/Markdown.cs
+++ b/Markdown.cs
@@ -1,5 +1,6 @@
 ﻿using System.IO;
 
+using Cake.Common.IO;
 using Cake.Core;
 using Cake.Core.IO;
 
@@ -11,11 +12,11 @@ namespace Dnn.CakeUtils
     {
         public static string ToHtml(this ICakeContext context, FilePath fileName)
         {
-            if (File.Exists(fileName.FullPath))
+            if (context.FileExists(fileName))
             {
                 var input = "";
                 var pipeline = new MarkdownPipelineBuilder().UseAdvancedExtensions().Build();
-                using (var sr = new StreamReader(fileName.FullPath))
+                using (var sr = new StreamReader(context.MakeAbsolute(fileName).FullPath))
                 {
                     input = sr.ReadToEnd();
                 }

--- a/Markdown.cs
+++ b/Markdown.cs
@@ -1,14 +1,15 @@
 ﻿using System.IO;
 
+using Cake.Core;
 using Cake.Core.IO;
 
 using Markdig;
 
 namespace Dnn.CakeUtils
 {
-    public class Markdown
+    public static class Markdown
     {
-        public static string ToHtml(FilePath fileName)
+        public static string ToHtml(this ICakeContext context, FilePath fileName)
         {
             if (File.Exists(fileName.FullPath))
             {

--- a/Markdown.cs
+++ b/Markdown.cs
@@ -1,17 +1,20 @@
-﻿using Markdig;
-using System.IO;
+﻿using System.IO;
+
+using Cake.Core.IO;
+
+using Markdig;
 
 namespace Dnn.CakeUtils
 {
     public class Markdown
     {
-        public static string ToHtml(string fileName)
+        public static string ToHtml(FilePath fileName)
         {
-            if (File.Exists(fileName))
+            if (File.Exists(fileName.FullPath))
             {
                 var input = "";
                 var pipeline = new MarkdownPipelineBuilder().UseAdvancedExtensions().Build();
-                using (var sr = new StreamReader(fileName))
+                using (var sr = new StreamReader(fileName.FullPath))
                 {
                     input = sr.ReadToEnd();
                 }

--- a/Packaging.cs
+++ b/Packaging.cs
@@ -2,6 +2,7 @@
 using Cake.Common.IO;
 using Cake.Core;
 using Cake.Core.Annotations;
+using Cake.Core.IO;
 using System.Linq;
 
 namespace Dnn.CakeUtils
@@ -9,7 +10,7 @@ namespace Dnn.CakeUtils
     public static class Packaging
     {
         [CakeMethodAlias]
-        public static void AddResourceZip(this ICakeContext context, Solution solution, Project project, string devPath, string packagePath)
+        public static void AddResourceZip(this ICakeContext context, Solution solution, Project project, DirectoryPath devPath, FilePath packagePath)
         {
             var releaseFiles = project.pathsAndFiles.releaseFiles == null ? solution.dnn.pathsAndFiles.releaseFiles : project.pathsAndFiles.releaseFiles;
             if (releaseFiles.Length > 0)
@@ -34,7 +35,7 @@ namespace Dnn.CakeUtils
             }
         }
         [CakeMethodAlias]
-        public static void AddScripts(this ICakeContext context, Solution solution, Project project, string packagePath)
+        public static void AddScripts(this ICakeContext context, Solution solution, Project project, FilePath packagePath)
         {
             if (!string.IsNullOrEmpty(project.pathsAndFiles.pathToScripts))
             {
@@ -43,7 +44,7 @@ namespace Dnn.CakeUtils
             }
         }
         [CakeMethodAlias]
-        public static void AddCleanupFiles(this ICakeContext context, Solution solution, Project project, string packagePath)
+        public static void AddCleanupFiles(this ICakeContext context, Solution solution, Project project, FilePath packagePath)
         {
             if (!string.IsNullOrEmpty(project.pathsAndFiles.pathToCleanupFiles))
             {
@@ -52,7 +53,7 @@ namespace Dnn.CakeUtils
             }
         }
         [CakeMethodAlias]
-        public static void AddLicenseAndReleaseNotes(this ICakeContext context, Solution solution, Project project, string packagePath)
+        public static void AddLicenseAndReleaseNotes(this ICakeContext context, Solution solution, Project project, FilePath packagePath)
         {
             if (!string.IsNullOrEmpty(project.pathsAndFiles.licenseFile))
             {

--- a/Packaging.cs
+++ b/Packaging.cs
@@ -27,9 +27,9 @@ namespace Dnn.CakeUtils
                 var files = context.GetFilesByPatterns(devPath, releaseFiles, excludeFiles);
                 if (files.Count > 0)
                 {
-                    var resZip = Compression.ZipToBytes(devPath, files);
+                    var resZip = context.ZipToBytes(devPath, files);
                     context.Information("Zipped resources file");
-                    Compression.AddBinaryFileToZip(packagePath, resZip, project.packageName.NoSlashes() + ".zip", true);
+                    context.AddBinaryFileToZip(packagePath, resZip, project.packageName.NoSlashes() + ".zip", true);
                 }
                 context.Information("Added resources from " + devPath);
             }
@@ -40,7 +40,7 @@ namespace Dnn.CakeUtils
             if (!string.IsNullOrEmpty(project.pathsAndFiles.pathToScripts))
             {
                 var files = context.GetFiles(project.pathsAndFiles.pathToScripts + "/*.SqlDataProvider");
-                Compression.AddFilesToZip(packagePath, project.pathsAndFiles.pathToScripts, solution.dnn.pathsAndFiles.packageScriptsFolder + "/" + project.packageName.NoSlashes(), files, true);
+                context.AddFilesToZip(packagePath, project.pathsAndFiles.pathToScripts, solution.dnn.pathsAndFiles.packageScriptsFolder + "/" + project.packageName.NoSlashes(), files, true);
             }
         }
         [CakeMethodAlias]
@@ -49,7 +49,7 @@ namespace Dnn.CakeUtils
             if (!string.IsNullOrEmpty(project.pathsAndFiles.pathToCleanupFiles))
             {
                 var files = context.GetFiles(project.pathsAndFiles.pathToCleanupFiles + "/*.txt");
-                Compression.AddFilesToZip(packagePath, project.pathsAndFiles.pathToCleanupFiles, solution.dnn.pathsAndFiles.packageCleanupFolder + "/" + project.packageName.NoSlashes(), files, true);
+                context.AddFilesToZip(packagePath, project.pathsAndFiles.pathToCleanupFiles, solution.dnn.pathsAndFiles.packageCleanupFolder + "/" + project.packageName.NoSlashes(), files, true);
             }
         }
         [CakeMethodAlias]
@@ -57,18 +57,18 @@ namespace Dnn.CakeUtils
         {
             if (!string.IsNullOrEmpty(project.pathsAndFiles.licenseFile))
             {
-                var license = Utilities.GetTextOrMdFile(project.pathsAndFiles.licenseFile);
+                var license = context.GetTextOrMdFile(project.pathsAndFiles.licenseFile);
                 if (license != "")
                 {
-                    Compression.AddTextFileToZip(packagePath, license, project.packageName.NoSlashes() + "/License.txt", true);
+                    context.AddTextFileToZip(packagePath, license, project.packageName.NoSlashes() + "/License.txt", true);
                 }
             }
             if (!string.IsNullOrEmpty(project.pathsAndFiles.releaseNotesFile))
             {
-                var releaseNotes = Utilities.GetTextOrMdFile(project.pathsAndFiles.releaseNotesFile);
+                var releaseNotes = context.GetTextOrMdFile(project.pathsAndFiles.releaseNotesFile);
                 if (releaseNotes != "")
                 {
-                    Compression.AddTextFileToZip(packagePath, releaseNotes, project.packageName.NoSlashes() + "/ReleaseNotes.txt", true);
+                    context.AddTextFileToZip(packagePath, releaseNotes, project.packageName.NoSlashes() + "/ReleaseNotes.txt", true);
                 }
             }
         }

--- a/Solution.cs
+++ b/Solution.cs
@@ -1,5 +1,8 @@
-﻿using Newtonsoft.Json;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+
+using Cake.Core.IO;
+
+using Newtonsoft.Json;
 
 namespace Dnn.CakeUtils
 {
@@ -9,7 +12,7 @@ namespace Dnn.CakeUtils
         public string version { get; set; }
         public string description { get; set; }
         public DnnSolution dnn { get; set; }
-        public static Solution New(string packageJsonFilePath)
+        public static Solution New(FilePath packageJsonFilePath)
         {
             var sln = JsonConvert.DeserializeObject<Solution>(Utilities.ReadFile(packageJsonFilePath));
             foreach (var folder in sln.dnn.projectFolders)

--- a/Utilities.cs
+++ b/Utilities.cs
@@ -1,14 +1,15 @@
 ﻿using System;
 using System.IO;
 
+using Cake.Common.Diagnostics;
 using Cake.Core;
 using Cake.Core.IO;
 
 namespace Dnn.CakeUtils
 {
-    public class Utilities
+    public static class Utilities
     {
-        public static void UpdateAssemblyInfo(Solution sln, FilePath filePath)
+        public static void UpdateAssemblyInfo(this ICakeContext context, Solution sln, FilePath filePath)
         {
             var ai = new AssemblyInfo(filePath);
             ai.SetProperty("AssemblyVersion", sln.version);
@@ -20,7 +21,7 @@ namespace Dnn.CakeUtils
             ai.Write();
         }
 
-        public static void UpdateAssemblyInfoVersion(Version version, string informationalVersion, FilePath filePath)
+        public static void UpdateAssemblyInfoVersion(this ICakeContext context, Version version, string informationalVersion, FilePath filePath)
         {
             var ai = new AssemblyInfo(filePath);
             ai.SetProperty("AssemblyVersion", version.ToString(3));
@@ -32,7 +33,7 @@ namespace Dnn.CakeUtils
             ai.Write();
         }
 
-        public static void UpdateCsProjFile(Solution sln, FilePath filePath)
+        public static void UpdateCsProjFile(this ICakeContext context, Solution sln, FilePath filePath)
         {
             var projFile = new CsProjFile(filePath);
             if (!projFile.IsNetCore)
@@ -48,21 +49,26 @@ namespace Dnn.CakeUtils
             projFile.Write();
         }
 
-        public static string GetTextOrMdFile(FilePath filePathWithExtension)
+        public static string GetTextOrMdFile(this ICakeContext context, FilePath filePathWithExtension)
         {
             var filePath = filePathWithExtension.GetDirectory().CombineWithFilePath(filePathWithExtension.GetFilenameWithoutExtension());
-            Console.WriteLine("GetTextOrMdFile {0}", filePath);
+            context.Information("GetTextOrMdFile {0}", filePath);
             if (File.Exists(filePath + ".md"))
             {
-                Console.WriteLine("MD Found");
-                return Markdown.ToHtml(filePath + ".md");
+                context.Information("MD Found");
+                return context.ToHtml(filePath + ".md");
             }
             if (File.Exists(filePath + ".txt"))
             {
-                Console.WriteLine("TXT Found");
-                return ReadFile(filePath + ".txt");
+                context.Information("TXT Found");
+                return context.ReadFile(filePath + ".txt");
             }
             return "";
+        }
+
+        public static string ReadFile(this ICakeContext context, FilePath filePath)
+        {
+            return ReadFile(filePath);
         }
 
         public static string ReadFile(FilePath filePath)
@@ -73,16 +79,16 @@ namespace Dnn.CakeUtils
             }
         }
 
-        public static void CreateResourcesFile(ICakeContext context, FilePath path, FilePath packagePath, FilePath packageName, string[] releaseFiles, string[] excludeFiles)
+        public static void CreateResourcesFile(this ICakeContext context, DirectoryPath path, FilePath packagePath, FilePath packageName, string[] releaseFiles, string[] excludeFiles)
         {
             var files = context.GetFilesByPatterns(path, releaseFiles, excludeFiles);
             if (files.Count > 0)
             {
-                var resZip = Compression.ZipToBytes(path, files);
-                Console.WriteLine("Zipped resources file");
-                Compression.AddBinaryFileToZip(packagePath, resZip, packageName + ".zip", true);
+                var resZip = context.ZipToBytes(path, files);
+                context.Information("Zipped resources file");
+                context.AddBinaryFileToZip(packagePath, resZip, packageName + ".zip", true);
             }
-            Console.WriteLine("Added resources from " + path);
+            context.Information("Added resources from " + path);
         }
     }
 }

--- a/Utilities.cs
+++ b/Utilities.cs
@@ -1,12 +1,14 @@
-﻿using Cake.Core;
-using System;
+﻿using System;
 using System.IO;
+
+using Cake.Core;
+using Cake.Core.IO;
 
 namespace Dnn.CakeUtils
 {
     public class Utilities
     {
-        public static void UpdateAssemblyInfo(Solution sln, string filePath)
+        public static void UpdateAssemblyInfo(Solution sln, FilePath filePath)
         {
             var ai = new AssemblyInfo(filePath);
             ai.SetProperty("AssemblyVersion", sln.version);
@@ -14,11 +16,11 @@ namespace Dnn.CakeUtils
             ai.SetProperty("AssemblyTitle", sln.name);
             ai.SetProperty("AssemblyDescription", sln.description);
             ai.SetProperty("AssemblyCompany", sln.dnn.owner.organization);
-            ai.SetProperty("AssemblyCopyright", string.Format("Copyright {0} by {1}", System.DateTime.Now.Year, sln.dnn.owner.organization));
+            ai.SetProperty("AssemblyCopyright", $"Copyright {System.DateTime.Now.Year} by {sln.dnn.owner.organization}");
             ai.Write();
         }
 
-        public static void UpdateAssemblyInfoVersion(Version version, string informationalVersion, string filePath)
+        public static void UpdateAssemblyInfoVersion(Version version, string informationalVersion, FilePath filePath)
         {
             var ai = new AssemblyInfo(filePath);
             ai.SetProperty("AssemblyVersion", version.ToString(3));
@@ -30,7 +32,7 @@ namespace Dnn.CakeUtils
             ai.Write();
         }
 
-        public static void UpdateCsProjFile(Solution sln, string filePath)
+        public static void UpdateCsProjFile(Solution sln, FilePath filePath)
         {
             var projFile = new CsProjFile(filePath);
             if (!projFile.IsNetCore)
@@ -42,13 +44,13 @@ namespace Dnn.CakeUtils
             projFile.SetProperty("Product", sln.name);
             projFile.SetProperty("Description", sln.description);
             projFile.SetProperty("Company", sln.dnn.owner.organization);
-            projFile.SetProperty("Copyright", string.Format("Copyright {0} by {1}", System.DateTime.Now.Year, sln.dnn.owner.organization));
+            projFile.SetProperty("Copyright", $"Copyright {System.DateTime.Now.Year} by {sln.dnn.owner.organization}");
             projFile.Write();
         }
 
-        public static string GetTextOrMdFile(string filePathWithExtension)
+        public static string GetTextOrMdFile(FilePath filePathWithExtension)
         {
-            var filePath = Path.Combine(Path.GetDirectoryName(filePathWithExtension), Path.GetFileNameWithoutExtension(filePathWithExtension));
+            var filePath = filePathWithExtension.GetDirectory().CombineWithFilePath(filePathWithExtension.GetFilenameWithoutExtension());
             Console.WriteLine("GetTextOrMdFile {0}", filePath);
             if (File.Exists(filePath + ".md"))
             {
@@ -63,17 +65,15 @@ namespace Dnn.CakeUtils
             return "";
         }
 
-        public static string ReadFile(string filePath)
+        public static string ReadFile(FilePath filePath)
         {
-            var output = "";
-            using (var sr = new System.IO.StreamReader(filePath))
+            using (var sr = new System.IO.StreamReader(filePath.FullPath))
             {
-                output = sr.ReadToEnd();
+                return sr.ReadToEnd();
             }
-            return output;
         }
 
-        public static void CreateResourcesFile(ICakeContext context, string path, string packagePath, string packageName, string[] releaseFiles, string[] excludeFiles)
+        public static void CreateResourcesFile(ICakeContext context, FilePath path, FilePath packagePath, FilePath packageName, string[] releaseFiles, string[] excludeFiles)
         {
             var files = context.GetFilesByPatterns(path, releaseFiles, excludeFiles);
             if (files.Count > 0)

--- a/Utilities.cs
+++ b/Utilities.cs
@@ -2,6 +2,7 @@
 using System.IO;
 
 using Cake.Common.Diagnostics;
+using Cake.Common.IO;
 using Cake.Core;
 using Cake.Core.IO;
 
@@ -68,7 +69,7 @@ namespace Dnn.CakeUtils
 
         public static string ReadFile(this ICakeContext context, FilePath filePath)
         {
-            return ReadFile(filePath);
+            return ReadFile(context.MakeAbsolute(filePath));
         }
 
         public static string ReadFile(FilePath filePath)


### PR DESCRIPTION
The build failure for https://github.com/dnnsoftware/Dnn.Platform/pull/4554 is coming from a method signature change between Cake 0.37.0 (which this project currently references) and Cake 1.x (which DNN references).

This PR upgrades the version of Cake referenced by this project to 1.0.0 to avoid these conflicts.

It also adjusts the API to use Cake's path types and to use Cake for logging where appropriate.

Because of the breaking changes in the API surface, this also bumps the version to 2.0.0