### PR TITLE
Simplify new ParsedAssemblies helpers

### DIFF
--- a/Dnn.CakeUtils.csproj
+++ b/Dnn.CakeUtils.csproj
@@ -6,10 +6,10 @@
     <Authors>DNN Community</Authors>
     <Description>Utilities to support Cake scripts for building and packaging DNN extensions</Description>
     <PackageProjectUrl>https://github.com/DNNCommunity/Dnn.CakeUtils</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/DNNCommunity/Dnn.CakeUtils/blob/master/LICENSE</PackageLicenseUrl>
     <Version>2.1.3</Version>
     <AssemblyVersion>2.1.3.0</AssemblyVersion>
     <FileVersion>2.1.3.0</FileVersion>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Dnn.CakeUtils.csproj
+++ b/Dnn.CakeUtils.csproj
@@ -6,10 +6,10 @@
     <Authors>DNN Community</Authors>
     <Description>Utilities to support Cake scripts for building and packaging DNN extensions</Description>
     <PackageProjectUrl>https://github.com/DNNCommunity/Dnn.CakeUtils</PackageProjectUrl>
-    <Version>2.1.3</Version>
-    <AssemblyVersion>2.1.3.0</AssemblyVersion>
-    <FileVersion>2.1.3.0</FileVersion>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <Version>2.1.4</Version>
+    <AssemblyVersion>2.1.4.0</AssemblyVersion>
+    <FileVersion>2.1.4.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ParsedAssembly.cs
+++ b/ParsedAssembly.cs
@@ -6,6 +6,7 @@ using System.Runtime.Versioning;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Xml;
+using System.Xml.Linq;
 
 namespace Dnn.CakeUtils
 {
@@ -80,12 +81,18 @@ namespace Dnn.CakeUtils
       return builder.ToString();
     }
 
-    public string AssemblyBindingRedirect()
+    public XElement AssemblyBindingRedirect()
     {
-      return $@"      <dependentAssembly>
-        <assemblyIdentity name=""{this.Name}"" publicKeyToken=""{PublicKeyToken}"" culture=""neutral"" />
-        <bindingRedirect oldVersion=""0.0.0.0-32767.32767.32767.32767"" newVersion=""{Version}""/>
-      </dependentAssembly>";
+      XNamespace asm = "urn:schemas-microsoft-com:asm.v1";
+      return new XElement(asm + "dependentAssembly",
+        new XElement(
+          asm + "assemblyIdentity",
+          new XAttribute("name", this.Name),
+          this.PublicKeyToken is null ? null : new XAttribute("publicKeyToken", this.PublicKeyToken)),
+        new XElement(
+          asm + "bindingRedirect",
+          new XAttribute("oldVersion", "0.0.0.0-32767.32767.32767.32767"),
+          new XAttribute("newVersion", this.Version)));
     }
   }
 }

--- a/ParsedAssembly.cs
+++ b/ParsedAssembly.cs
@@ -34,6 +34,12 @@ namespace Dnn.CakeUtils
       this.Version = details.Version.ToString();
       this.PublicKeyToken = ReadPublicKey(details);
 
+      var references = assembly.GetReferencedAssemblies();
+      foreach (var reference in references.OrderBy(r => r.Name))
+      {
+        References.Add($"{reference.Name} {reference.Version}");
+      }
+
       try
       {
         var targetFrameworkAttribute = assembly.GetCustomAttribute<TargetFrameworkAttribute>();
@@ -51,13 +57,6 @@ namespace Dnn.CakeUtils
       catch (Exception ex)
       {
         this.Exception = $"Error reading TargetFrameworkAttribute: {ex.Message}";
-        return;
-      }
-
-      var references = assembly.GetReferencedAssemblies();
-      foreach (var reference in references.OrderBy(r => r.Name))
-      {
-        References.Add($"{reference.Name} {reference.Version}");
       }
     }
 

--- a/ParsedAssembly.cs
+++ b/ParsedAssembly.cs
@@ -14,7 +14,6 @@ namespace Dnn.CakeUtils
   {
     public string Name { get; set; } = "";
     public string PublicKeyToken { get; set; } = "";
-    public string FilePath { get; set; } = "";
     public string Version { get; set; } = "";
     public string TargetFramework { get; set; } = "";
     public string TargetFrameworkVersion { get; set; } = "";
@@ -33,21 +32,19 @@ namespace Dnn.CakeUtils
 
       this.Name = details.Name;
       this.Version = details.Version.ToString();
+      this.PublicKeyToken = ReadPublicKey(details);
 
       try
       {
-        var targetFrameworkAttributes = assembly.CustomAttributes
-              .Where(attribute => attribute.AttributeType.Name == nameof(TargetFrameworkAttribute));
-        var customAttribute = targetFrameworkAttributes.FirstOrDefault();
-        var customAttributeValue = customAttribute?.ConstructorArguments.FirstOrDefault().Value.ToString();
-        this.PublicKeyToken = ReadPublicKey(details);
-        if (string.IsNullOrEmpty(customAttributeValue))
+        var targetFrameworkAttribute = assembly.GetCustomAttribute<TargetFrameworkAttribute>();
+        var frameworkName = targetFrameworkAttribute?.FrameworkName;
+        if (string.IsNullOrEmpty(frameworkName))
         {
           this.Exception = "No TargetFrameworkAttribute found";
           return;
         }
 
-        var parts = customAttributeValue.Split(',');
+        var parts = frameworkName.Split(',');
         TargetFramework = parts[0];
         TargetFrameworkVersion = parts[1];
       }

--- a/ParsedAssembly.cs
+++ b/ParsedAssembly.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.Versioning;
+using System.Text;
 using System.Text.RegularExpressions;
 using System.Xml;
 
@@ -10,8 +11,6 @@ namespace Dnn.CakeUtils
 {
   public class ParsedAssembly
   {
-    private static readonly Regex PublicKeyTokenRegex = new Regex(@"PublicKeyToken=(\w+)", RegexOptions.CultureInvariant | RegexOptions.Compiled);
-
     public string Name { get; set; } = "";
     public string PublicKeyToken { get; set; } = "";
     public string FilePath { get; set; } = "";
@@ -36,9 +35,9 @@ namespace Dnn.CakeUtils
 
       try
       {
-        var targetFrameWorkAttributes = assembly.CustomAttributes
+        var targetFrameworkAttributes = assembly.CustomAttributes
               .Where(attribute => attribute.AttributeType.Name == nameof(TargetFrameworkAttribute));
-        var customAttribute = targetFrameWorkAttributes.FirstOrDefault();
+        var customAttribute = targetFrameworkAttributes.FirstOrDefault();
         var customAttributeValue = customAttribute?.ConstructorArguments.FirstOrDefault().Value.ToString();
         this.PublicKeyToken = ReadPublicKey(details);
         if (string.IsNullOrEmpty(customAttributeValue))
@@ -64,14 +63,21 @@ namespace Dnn.CakeUtils
       }
     }
 
-    private string ReadPublicKey(AssemblyName assemblyName)
+    private static string ReadPublicKey(AssemblyName assemblyName)
     {
-      if (assemblyName == null || !assemblyName.Flags.HasFlag(AssemblyNameFlags.PublicKey))
+      var publicKeyToken = assemblyName.GetPublicKeyToken();
+      if (publicKeyToken == null || publicKeyToken.Length == 0)
       {
         return null;
       }
 
-      return PublicKeyTokenRegex.Match(assemblyName.FullName).Groups[1].Value;
+      var builder = new StringBuilder(publicKeyToken.Length * 2);
+      foreach (var b in publicKeyToken)
+      {
+        builder.AppendFormat($"{b:x2}");
+      }
+		
+      return builder.ToString();
     }
 
     public string AssemblyBindingRedirect()

--- a/Utilities.cs
+++ b/Utilities.cs
@@ -130,7 +130,7 @@ namespace Dnn.CakeUtils
 
     public static List<ParsedAssembly> ParseAssemblies(this FilePathCollection assemblies)
     {
-      var res = new List<ParsedAssembly>();
+      var res = new List<ParsedAssembly>(assemblies.Count);
       foreach (var file in assemblies)
       {
         try


### PR DESCRIPTION
- Change `AssemblyBindingRedirect` from `string` to `XElement`, so that namespaces just work
- Use `GetPublicKeyToken` API instead of parsing via Regex (ensure it's always `null` if there's no value)
- Ensure properties get filled out even if there's an error reading `TargetFrameworkAttribute`